### PR TITLE
Add enhanced metrics

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -8,6 +8,7 @@
 
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 import {createPlugin} from 'fusion-core';
+import browserPerfCollector from './helpers/enhancedBrowserMetrics';
 
 class BrowserPerformanceEmitter {
   constructor() {
@@ -87,6 +88,10 @@ export default __BROWSER__ &&
               resourceEntries,
               firstPaint,
               tags: browserPerformanceEmitter.tags,
+              // Piggy-back enhaned metrics, for perf dashboard etc on this emit.
+              // Eventually this will probably be the only data emitted but preserving
+              // legacy data shape for now
+              enhancedMetrics: browserPerfCollector(window),
             });
           }, 0);
         });

--- a/src/helpers/enhancedBrowserMetrics.js
+++ b/src/helpers/enhancedBrowserMetrics.js
@@ -1,0 +1,103 @@
+function hasPerf(window) {
+  return Boolean(
+    window.performance &&
+      window.performance.timing &&
+      window.performance.getEntriesByType
+  );
+}
+
+function getEntries(window) {
+  const resources = window.performance.getEntriesByType('resource');
+  const jsonResources = resources.filter(entry => {
+    return entry.name.indexOf('data:') !== 0 && entry.toJSON;
+  });
+  return jsonResources.map(entry => entry.toJSON());
+}
+
+function getServerTiming(window) {
+  const navigationTiming = window.performance.getEntriesByType('navigation')[0];
+  return navigationTiming.serverTiming;
+}
+
+function getTiming(window) {
+  return asDictionary(window.performance.timing);
+}
+
+function getNetwork(window) {
+  return window.navigator.connection;
+}
+
+function getMemory(window) {
+  return window.performance.memory;
+}
+
+function getFirstPaint(window) {
+  if (window.chrome && window.chrome.loadTimes) {
+    // Chrome
+    const firstPaint = window.chrome.loadTimes().firstPaintTime * 1000;
+    return firstPaint - window.chrome.loadTimes().startLoadTime * 1000;
+  } else if (typeof window.performance.timing.msFirstPaint === 'number') {
+    // IE
+    const firstPaint = window.performance.timing.msFirstPaint;
+    return firstPaint - window.performance.timing.navigationStart;
+  }
+  return null;
+}
+
+function getWidth(window) {
+  const document = window.document;
+  return Math.max(
+    document.body.scrollWidth,
+    document.documentElement.scrollWidth,
+    document.body.offsetWidth,
+    document.documentElement.offsetWidth,
+    document.documentElement.clientWidth
+  );
+}
+
+function getHeight(window) {
+  const document = window.document;
+  return Math.max(
+    document.body.scrollHeight,
+    document.documentElement.scrollHeight,
+    document.body.offsetHeight,
+    document.documentElement.offsetHeight,
+    document.documentElement.clientHeight
+  );
+}
+
+function getDeviceDimensions(window) {
+  const height = getHeight(window);
+  const width = getWidth(window);
+  return {height, width};
+}
+
+const browserPerfCollector = window => {
+  if (!hasPerf(window)) {
+    return {};
+  }
+
+  return {
+    navigation: getTiming(window),
+    resources: getEntries(window),
+    server: getServerTiming(window),
+    firstPaint: getFirstPaint(window),
+    memory: getMemory(window),
+    network: getNetwork(window),
+    dimensions: getDeviceDimensions(window),
+  };
+};
+
+function asDictionary(obj) {
+  if (obj.toJSON && typeof obj.toJSON === 'function') {
+    return obj.toJSON();
+  }
+  return Object.keys(Object.getPrototypeOf(obj)).reduce((result, key) => {
+    if (typeof obj[key] !== 'function') {
+      result[key] = obj[key];
+    }
+    return result;
+  }, {});
+}
+
+export default browserPerfCollector;


### PR DESCRIPTION
Resolves #81

The Web Performance Dashboard (and other features associated with our 2018 performance and quality visualization effort) needs additional data and in a format appropriate for the https://watchtower.uberinternal.com/watchtower/#topic=hp-unified_logging-web-performance schema.

For now I'm keeping the existing metrics for backwards compatibility (e.g used by hp-event-web)